### PR TITLE
fix inherited the wrong interface

### DIFF
--- a/src/OpenRpg.Genres/Types/GenreVariableTypes.cs
+++ b/src/OpenRpg.Genres/Types/GenreVariableTypes.cs
@@ -4,7 +4,7 @@ using OpenRpg.Quests.Types;
 
 namespace OpenRpg.Genres.Types
 {
-    public interface GenreVariableTypes : CombatVariableTypes, QuestVariableTypes, ItemVariableTypes
+    public interface GenreVariableTypes : CombatVariableTypes, QuestVariableTypes, ItemCoreVariableTypes
     {
     }
 }


### PR DESCRIPTION
It should be `ItemCoreVariableTypes` not `ItemVariableTypes`.